### PR TITLE
Spelling fixes for Sorcerer

### DIFF
--- a/end.zil
+++ b/end.zil
@@ -149,7 +149,7 @@ lies to the northwest.">)>
 		<PERFORM ,V?DRINK ,WATER>
 		<RTRUE>)
 	       (<VERB? EXAMINE>
-		<TELL "It streches east as far as the eye can see." CR>)
+		<TELL "It stretches east as far as the eye can see." CR>)
 	       (<VERB? RESEARCH>
 		<TELL
 "The Flathead Ocean, called the Great Sea by the ancients, has a very

--- a/park.zil
+++ b/park.zil
@@ -316,7 +316,7 @@ protected against this sort of prank." CR>)
 		<RTRUE>)
 	       (<VERB? RESEARCH>
 		<TELL
-"Flumes are artifical water channels, usually with boat rides. The
+"Flumes are artificial water channels, usually with boat rides. The
 boat is typically a hollowed-out log. The largest flume of this kind
 is in Bozbarland." CR>)>>
 

--- a/verbs.zil
+++ b/verbs.zil
@@ -2922,7 +2922,7 @@ your demise is permanent." CR>
 				   <NOT ,RIVER-EVAPORATED>>
 			      <TELL
 "A moment later you find yourself at the bottom of a river, between
-a whirpool, some sharp rocks, and a school of river sharks. This time,
+a whirlpool, some sharp rocks, and a school of river sharks. This time,
 your death is terminal." CR>
 			      <FINISH>)
 			     (<AND <IN-GUILD-HALL? ,RESURRECTION-ROOM>


### PR DESCRIPTION
These are the spelling fixes for Sorcerer from The ZIL Files. The usual caveats apply: I'm not a native English speaker, so please check that the fixes are correct.